### PR TITLE
Install git-filter-repo tool in common/git role

### DIFF
--- a/roles/common/git/tasks/main.yml
+++ b/roles/common/git/tasks/main.yml
@@ -1,13 +1,24 @@
 ---
 - name: Install git (linux)
   become: true
-  ansible.builtin.apt:
-    name: git
-    state: latest
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  block:
+    - name: Install git (linux)
+      ansible.builtin.apt:
+        name: git
+        state: latest
+
+# TODO: install git-filter-repo on linux
 
 - name: Install git (macos)
-  community.general.homebrew:
-    name: git
-    state: latest
   when: ansible_distribution == 'MacOSX'
+  block:
+    - name: Install git (macos)
+      community.general.homebrew:
+        name: git
+        state: latest
+
+    - name: Install git-filter-repo (macos)
+      community.general.homebrew:
+        name: git-filter-repo
+        state: latest


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Installs the `git-filter-repo` tool on macOS via Homebrew as part of the `common/git` role. Restructures the role to use per-platform `block` sections so additional tools can be added per-OS, and adds a TODO for Linux support.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```