### PR TITLE
Add common/poppler role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -49,6 +49,7 @@
     - common/make
     - common/nmap
     - common/notify
+    - common/poppler
     - common/unzip
     - common/wget
     - drivers/cpu

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -52,6 +52,7 @@
     - common/make
     - common/nmap
     - common/notify
+    - common/poppler
     - common/unzip
     - common/wget
     - drivers/cpu

--- a/roles/common/poppler/tasks/main.yml
+++ b/roles/common/poppler/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# TODO: install poppler on linux
+
+- name: Install poppler (macos)
+  community.general.homebrew:
+    name: poppler
+    state: latest
+  when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new `common/poppler` role that installs the `poppler` PDF utilities via Homebrew on macOS, and wires it into both the Linux and macOS playbooks. Linux installation is left as a TODO.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```