### PR TITLE
Replace mas with homebrew cask in communication/whatsapp role

### DIFF
--- a/roles/communication/whatsapp/tasks/main.yml
+++ b/roles/communication/whatsapp/tasks/main.yml
@@ -35,8 +35,7 @@
         mode: "0644"
 
 - name: Install whatsapp (macos)
-  become: true
-  ansible.builtin.command: mas install 310633997
-  register: whatsapp_result
-  changed_when: whatsapp_result.stdout != "" and "is already installed" not in whatsapp_result.stdout
+  community.general.homebrew_cask:
+    name: whatsapp
+    state: present
   when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Swaps the macOS WhatsApp install from `mas install 310633997` (Mac App Store CLI) to a `community.general.homebrew_cask` task. This removes the dependency on `mas` and the brittle `register`/`changed_when` parsing of command output in favor of idempotent package management consistent with the rest of the macOS roles.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```