### PR TITLE
Switch to claude-code@latest cask in development/claude role

### DIFF
--- a/roles/development/claude/tasks/main.yml
+++ b/roles/development/claude/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Install claude (macos)
   community.general.homebrew_cask:
-    name: claude-code
+    name: claude-code@latest
     install_options: appdir=/Applications
     state: latest
   when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Updates the macOS install task to use the `claude-code@latest` Homebrew cask instead of `claude-code`. The `@latest` variant tracks the rolling release channel, which is what this role is intended to install.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```