### PR TITLE
Install virtualbox dependency in development/vagrant role

### DIFF
--- a/roles/development/vagrant/tasks/main.yml
+++ b/roles/development/vagrant/tasks/main.yml
@@ -40,6 +40,12 @@
 - name: Install vagrant (macOS)
   when: ansible_distribution == 'MacOSX'
   block:
+    - name: Install vagrant dependencies (macos)
+      community.general.homebrew_cask:
+        name: virtualbox
+        sudo_password: "{{ ansible_become_pass }}"
+        state: latest
+
     - name: Add vagrant tap (macos)
       community.general.homebrew_tap:
         name: hashicorp/tap


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a `virtualbox` Homebrew cask install task to the macOS branch of the `development/vagrant` role so the required provider is present before installing Vagrant itself. Matches the Linux side, which already installs `virtualbox-7.2` as a vagrant dependency.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```