### PR TITLE
Remove stale TODO in platform/screen role

### DIFF
--- a/roles/platform/screen/tasks/main.yml
+++ b/roles/platform/screen/tasks/main.yml
@@ -141,7 +141,6 @@
 - name: Configure screen (macos)
   when: ansible_distribution == 'MacOSX'
   block:
-    # TODO(tomdewildt): add tap to homebrew
     - name: Add skhd and yabai tap to homebrew (macos)
       community.general.homebrew_tap:
         name: asmvik/formulae


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Removes an obsolete `# TODO(tomdewildt): add tap to homebrew` comment from the macOS block in the `platform/screen` role. The tap is already added by the task immediately following the comment, so the TODO no longer applies.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```