### PR TITLE
Add productivity/meetily role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -114,6 +114,7 @@
     - productivity/evince
     - productivity/granola
     - productivity/maps
+    - productivity/meetily
     - productivity/sheets
     - productivity/slides
     - security/1password

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -117,6 +117,7 @@
     - productivity/evince
     - productivity/granola
     - productivity/maps
+    - productivity/meetily
     - productivity/sheets
     - productivity/slides
     - security/1password

--- a/roles/productivity/meetily/tasks/main.yml
+++ b/roles/productivity/meetily/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# TODO: install meetily on linux
+
+- name: Install meetily (macOS)
+  when: ansible_distribution == 'MacOSX'
+  block:
+    - name: Get meetily release (macos)
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/Zackriya-Solutions/meeting-minutes/releases/latest
+        return_content: true
+      register: meetily_release
+
+    - name: Download meetily dmg (macos)
+      ansible.builtin.get_url:
+        url: https://github.com/Zackriya-Solutions/meeting-minutes/releases/download/{{ meetily_release.json.tag_name }}/meetily_{{ meetily_release.json.tag_name | regex_replace('^v', '') }}_aarch64.dmg
+        dest: /tmp/meetily.dmg
+        mode: "0644"
+
+    - name: Mount meetily dmg (macos)
+      ansible.builtin.command:
+        cmd: hdiutil attach /tmp/meetily.dmg -nobrowse -mountpoint /tmp/meetily-mount
+        creates: /tmp/meetily-mount
+
+    - name: Copy meetily to applications (macos)
+      ansible.builtin.command:
+        cmd: cp -R /tmp/meetily-mount/meetily.app /Applications/meetily.app
+      changed_when: true
+
+    - name: Unmount meetily dmg (macos)
+      ansible.builtin.command:
+        cmd: hdiutil detach /tmp/meetily-mount
+        removes: /tmp/meetily-mount
+
+    - name: Remove meetily dmg (macos)
+      ansible.builtin.file:
+        path: /tmp/meetily.dmg
+        state: absent


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new `productivity/meetily` role that installs the Meetily meeting-minutes app on macOS. The role fetches the latest release metadata from GitHub, downloads the aarch64 `.dmg`, mounts it, copies `meetily.app` to `/Applications`, then unmounts and cleans up. Linux installation is left as a TODO. Wired into both the Linux and macOS playbooks.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```