### PR TITLE
Install 1password cli in security/1password role

### DIFF
--- a/roles/security/1password/tasks/main.yml
+++ b/roles/security/1password/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 # TODO: install 1password on linux
+# TODO: install 1password cli on linux
 
-- name: Install 1password (macos)
-  community.general.homebrew_cask:
-    name: 1password
-    install_options: appdir=/Applications
-    state: latest
+- name: Install 1password (macOS)
   when: ansible_distribution == 'MacOSX'
+  block:
+    - name: Install 1password (macos)
+      community.general.homebrew_cask:
+        name: 1password
+        install_options: appdir=/Applications
+        state: latest
+
+    - name: Install 1password cli (macos)
+      community.general.homebrew:
+        name: 1password-cli
+        state: latest


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a task to install the `1password-cli` Homebrew formula on macOS alongside the existing 1Password app, and restructures the macOS install into a `block` so additional 1Password components can be layered in. Adds a TODO for Linux CLI installation.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```