### PR TITLE
Add utilities/openvpn role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -122,6 +122,7 @@
     - utilities/characters
     - utilities/disk-utility
     - utilities/font-viewer
+    - utilities/openvpn
     - utilities/system-monitor
     - utilities/text-editor
     - config/files

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -125,6 +125,7 @@
     - utilities/characters
     - utilities/disk-utility
     - utilities/font-viewer
+    - utilities/openvpn
     - utilities/system-monitor
     - utilities/text-editor
     - config/files

--- a/roles/utilities/openvpn/tasks/main.yml
+++ b/roles/utilities/openvpn/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# TODO: install openvpn-connect on linux
+
+- name: Install openvpn-connect (macos)
+  community.general.homebrew_cask:
+    name: openvpn-connect
+    state: latest
+  when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new `utilities/openvpn` role that installs the `openvpn-connect` Homebrew cask on macOS, and wires it into both the Linux and macOS playbooks. Linux installation is left as a TODO.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```