### PR TITLE
Add common/age role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -34,6 +34,7 @@
         update_cache: true
         state: latest
   roles:
+    - common/age
     - common/curl
     - common/dig
     - common/exfat

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -37,6 +37,7 @@
       register: mas_result
       changed_when: mas_result.stdout != ""
   roles:
+    - common/age
     - common/curl
     - common/dig
     - common/exfat

--- a/roles/common/age/tasks/main.yml
+++ b/roles/common/age/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# TODO: install age on linux
+
+- name: Install age (macos)
+  community.general.homebrew:
+    name: age
+    state: latest
+  when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new `common/age` role that installs the `age` Homebrew package on macOS, and wires it into both the Linux and macOS playbooks. Linux installation is left as a TODO.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```