### PR TITLE
Add development/lmstudio role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -93,6 +93,7 @@
     - development/graphviz
     - development/imager
     - development/kamal
+    - development/lmstudio
     - development/mise
     - development/ngrok
     - development/ollama

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -96,6 +96,7 @@
     - development/graphviz
     - development/imager
     - development/kamal
+    - development/lmstudio
     - development/mise
     - development/ngrok
     - development/ollama

--- a/roles/development/lmstudio/tasks/main.yml
+++ b/roles/development/lmstudio/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# TODO: install lmstudio on linux
+
+- name: Install lmstudio (macos)
+  when: ansible_distribution == 'MacOSX'
+  block:
+    - name: Check if lmstudio is installed
+      ansible.builtin.stat:
+        path: /Users/{{ ansible_user }}/.lmstudio/bin/lms
+      register: lmstudio
+
+    - name: Download lmstudio install script (macos)
+      ansible.builtin.get_url:
+        url: https://lmstudio.ai/install.sh
+        dest: /tmp/lmstudio.sh
+        mode: "0755"
+      when: not lmstudio.stat.exists
+
+    - name: Install lmstudio (macos)
+      ansible.builtin.command: /tmp/lmstudio.sh
+      changed_when: "'Installing' in lmstudio_result.stdout"
+      register: lmstudio_result
+      when: not lmstudio.stat.exists


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new Ansible role for installing [LM Studio](https://lmstudio.ai) via its install script on macOS. The role is included in both the Linux and macOS playbooks (Linux installation is left as a TODO).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

The Linux task is stubbed with a TODO comment since LM Studio's install script currently targets macOS. The role checks whether LM Studio is already installed before attempting to download and run the installer.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```