### PR TITLE
Trust third-party brew taps in roles

### DIFF
--- a/roles/common/notify/tasks/main.yml
+++ b/roles/common/notify/tasks/main.yml
@@ -14,6 +14,11 @@
         name: vjeantet/tap
         state: present
 
+    - name: Trust alerter tap (macos)
+      ansible.builtin.command:
+        cmd: brew trust --tap vjeantet/tap
+      changed_when: false
+
     - name: Install alerter (macos)
       community.general.homebrew:
         name: vjeantet/tap/alerter

--- a/roles/development/packer/tasks/main.yml
+++ b/roles/development/packer/tasks/main.yml
@@ -34,6 +34,11 @@
         name: hashicorp/tap
         state: present
 
+    - name: Trust hashicorp tap (macos)
+      ansible.builtin.command:
+        cmd: brew trust --tap hashicorp/tap
+      changed_when: false
+
     - name: Install packer (macos)
       community.general.homebrew:
         name: hashicorp/tap/packer

--- a/roles/development/terraform/tasks/main.yml
+++ b/roles/development/terraform/tasks/main.yml
@@ -28,6 +28,11 @@
         name: hashicorp/tap
         state: present
 
+    - name: Trust hashicorp tap (macos)
+      ansible.builtin.command:
+        cmd: brew trust --tap hashicorp/tap
+      changed_when: false
+
     - name: Install terraform (macos)
       community.general.homebrew:
         name: hashicorp/tap/terraform

--- a/roles/development/vagrant/tasks/main.yml
+++ b/roles/development/vagrant/tasks/main.yml
@@ -51,6 +51,11 @@
         name: hashicorp/tap
         state: present
 
+    - name: Trust hashicorp tap (macos)
+      ansible.builtin.command:
+        cmd: brew trust --tap hashicorp/tap
+      changed_when: false
+
     - name: Install vagrant (macos)
       community.general.homebrew_cask:
         name: hashicorp/tap/hashicorp-vagrant

--- a/roles/platform/screen/tasks/main.yml
+++ b/roles/platform/screen/tasks/main.yml
@@ -146,6 +146,11 @@
         name: asmvik/formulae
         state: present
 
+    - name: Trust skhd and yabai tap (macos)
+      ansible.builtin.command:
+        cmd: brew trust --tap asmvik/formulae
+      changed_when: false
+
     - name: Install skhd (macos)
       community.general.homebrew:
         name: asmvik/formulae/skhd


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds `brew trust --tap` steps to roles that use third-party Homebrew taps. Homebrew now requires explicit trust for non-official taps, causing installs to fail without it.

- `common/notify` — trust `vjeantet/tap` (alerter)
- `development/packer` — trust `hashicorp/tap`
- `development/terraform` — trust `hashicorp/tap`
- `development/vagrant` — trust `hashicorp/tap`
- `platform/screen` — trust `asmvik/formulae` (skhd/yabai)

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```