### PR TITLE
Remove GitHub Copilot from VS Code extensions

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -14,8 +14,6 @@ config:
 
 code:
   extensions:
-    # AI
-    - github.copilot
     # Ansible
     - redhat.ansible
     # Docker


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Removes the `github.copilot` entry from the VS Code extensions list in group vars.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```