### PR TITLE
Add communication/teams role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -72,6 +72,7 @@
     - communication/meet
     - communication/signal
     - communication/slack
+    - communication/teams
     - communication/whatsapp
     - development/code
     - development/docker

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -75,6 +75,7 @@
     - communication/meet
     - communication/signal
     - communication/slack
+    - communication/teams
     - communication/whatsapp
     - development/code
     - development/docker

--- a/roles/communication/teams/tasks/main.yml
+++ b/roles/communication/teams/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# TODO: install microsoft-teams on linux
+
+- name: Install teams (macos)
+  community.general.homebrew_cask:
+    name: microsoft-teams
+    install_options: appdir=/Applications
+    sudo_password: "{{ ansible_become_pass }}"
+    state: latest
+  when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new `communication/teams` role that installs Microsoft Teams via Homebrew cask on macOS, with `sudo_password` for the `.pkg` installer. Includes the role in both playbooks.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Linux support is left as a TODO for now.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```