### PR TITLE
Add productivity/office role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -119,6 +119,7 @@
     - productivity/granola
     - productivity/maps
     - productivity/meetily
+    - productivity/office
     - productivity/sheets
     - productivity/slides
     - security/1password

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -122,6 +122,7 @@
     - productivity/granola
     - productivity/maps
     - productivity/meetily
+    - productivity/office
     - productivity/sheets
     - productivity/slides
     - security/1password

--- a/roles/productivity/office/tasks/main.yml
+++ b/roles/productivity/office/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# TODO: install microsoft-office on linux
+
+- name: Install microsoft-office (macos)
+  community.general.homebrew_cask:
+    name: microsoft-office
+    install_options: appdir=/Applications
+    sudo_password: "{{ ansible_become_pass }}"
+    state: latest
+  when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a new `productivity/office` role that installs Microsoft Office via Homebrew cask on macOS, with `sudo_password` for the `.pkg` installer. Includes the role in both playbooks.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Linux support is left as a TODO for now.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```