### PR TITLE
Add utilities/netbird role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -127,6 +127,7 @@
     - utilities/characters
     - utilities/disk-utility
     - utilities/font-viewer
+    - utilities/netbird
     - utilities/openvpn
     - utilities/system-monitor
     - utilities/text-editor

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -130,6 +130,7 @@
     - utilities/characters
     - utilities/disk-utility
     - utilities/font-viewer
+    - utilities/netbird
     - utilities/openvpn
     - utilities/system-monitor
     - utilities/text-editor

--- a/roles/utilities/netbird/tasks/main.yml
+++ b/roles/utilities/netbird/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# TODO: install netbird on linux
+
+- name: Install netbird (macOS)
+  when: ansible_distribution == 'MacOSX'
+  block:
+    - name: Download netbird pkg (macos)
+      ansible.builtin.get_url:
+        url: https://pkgs.netbird.io/macos/{{ 'arm64' if ansible_machine == 'arm64' else 'amd64' }}
+        dest: /tmp/netbird.pkg
+        mode: "0644"
+
+    - name: Install netbird pkg (macos)
+      become: true
+      ansible.builtin.command:
+        cmd: installer -pkg /tmp/netbird.pkg -target /
+      changed_when: true
+
+    - name: Remove netbird pkg (macos)
+      ansible.builtin.file:
+        path: /tmp/netbird.pkg
+        state: absent
+
+- name: Disable netbird ssh config
+  become: true
+  ansible.builtin.command:
+    cmd: netbird service reconfigure --service-env NB_DISABLE_SSH_CONFIG=true
+  changed_when: false


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Add a new `utilities/netbird` role that installs NetBird on macOS by downloading and installing the platform-specific pkg. The role also disables NetBird's SSH config management. Linux support is planned but not yet implemented.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

- Linux installation is not yet implemented (marked with a TODO).
- The role downloads the pkg to `/tmp/netbird.pkg` and cleans it up after installation.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```