### PR TITLE
Add development/duckdb role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -89,6 +89,7 @@
     - development/claude
     - development/codex
     - development/dive
+    - development/duckdb
     - development/gcp
     - development/github
     - development/gitlab

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -92,6 +92,7 @@
     - development/claude
     - development/codex
     - development/dive
+    - development/duckdb
     - development/gcp
     - development/github
     - development/gitlab

--- a/roles/development/duckdb/tasks/main.yml
+++ b/roles/development/duckdb/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# TODO: install duckdb on linux
+
+- name: Install duckdb (macos)
+  community.general.homebrew:
+    name: duckdb
+    state: latest
+  when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [x] Enhancement (new features, refinement)

**What this PR does / why we need it**:

Adds a `development/duckdb` role that installs the DuckDB CLI via Homebrew on macOS, and registers it in both the macOS and Linux playbooks. The Linux install path is stubbed with a `# TODO`, following the existing `bun`/`kamal` convention, since DuckDB is not packaged in the Debian repositories.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```