### PR TITLE
Add development/rust role

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -6,6 +6,7 @@ claude:
   plugins:
     - gopls-lsp
     - pyright-lsp
+    - rust-analyzer-lsp
     - typescript-lsp
 
 config:
@@ -44,6 +45,8 @@ code:
     - ms-python.python
     - ms-python.vscode-pylance
     - teticio.python-envy
+    # Rust
+    - rust-lang.rust-analyzer
     # Spellcheck
     - streetsidesoftware.code-spell-checker
     - streetsidesoftware.code-spell-checker-dutch
@@ -71,6 +74,13 @@ python:
     - pre-commit
     - pyright
     - virtualenv
+
+rust:
+  components:
+    - rustfmt
+    - clippy
+    - rust-analyzer
+    - rust-src
 
 vagrant:
   version: 2.4.0

--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -103,6 +103,7 @@
     - development/psql
     - development/pter
     - development/rtk
+    - development/rust
     - development/uv
     - media/easy-effects
     - media/eog

--- a/playbook-macos.yml
+++ b/playbook-macos.yml
@@ -85,6 +85,7 @@
     - development/packer
     - development/python
     - development/ruby
+    - development/rust
     - development/terraform
     - development/vagrant
     - development/aws

--- a/roles/development/rust/tasks/main.yml
+++ b/roles/development/rust/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# TODO: install rust on linux
+
+- name: Install rust (macos)
+  when: ansible_distribution == 'MacOSX'
+  block:
+    - name: Install rustup (macos)
+      community.general.homebrew:
+        name: rustup
+        state: latest
+
+    - name: Check rust active toolchain (macos)
+      ansible.builtin.command: /opt/homebrew/opt/rustup/bin/rustup show active-toolchain
+      register: rust_toolchain
+      changed_when: false
+      failed_when: false
+
+    - name: Install rust stable toolchain (macos)
+      ansible.builtin.command: /opt/homebrew/opt/rustup/bin/rustup default stable
+      changed_when: true
+      when: "'stable' not in (rust_toolchain.stdout | default(''))"
+
+    - name: Install rust components (macos)
+      ansible.builtin.command: /opt/homebrew/opt/rustup/bin/rustup component add {{ rust.components | join(' ') }}
+      register: rust_components
+      changed_when: "'installing component' in rust_components.stderr"


### PR DESCRIPTION
**What type of PR is this?**
- [x] Enhancement (new features, refinement)

**What this PR does / why we need it**:

Adds a `development/rust` role that installs `rustup` via Homebrew on macOS, sets the stable toolchain as default, and installs the standard tooling components (`rustfmt`, `clippy`, `rust-analyzer`, `rust-src`), with the component list driven from `group_vars`. Registers the role in both the macOS and Linux playbooks. The Linux install path is stubbed with a `# TODO`, following the existing `bun`/`duckdb` convention, since rustup is not packaged in the Debian repositories.

Also wires up the surrounding tooling: adds the `rust-lang.rust-analyzer` VS Code extension and the `rust-analyzer-lsp` Claude plugin.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```