### PR TITLE
Add linux install to common/age role

### DIFF
--- a/roles/common/age/tasks/main.yml
+++ b/roles/common/age/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
-# TODO: install age on linux
+- name: Install age (linux)
+  become: true
+  ansible.builtin.apt:
+    name: age
+    state: latest
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Install age (macos)
   community.general.homebrew:


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds the Linux (Debian/Ubuntu) install path to the `common/age` role, installing `age` via `apt`. The role previously only installed on macOS (Homebrew) and had a `TODO` for Linux.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
