### PR TITLE
Add linux install to common/git role

### DIFF
--- a/roles/common/git/tasks/main.yml
+++ b/roles/common/git/tasks/main.yml
@@ -1,14 +1,12 @@
 ---
 - name: Install git (linux)
   become: true
+  ansible.builtin.apt:
+    name:
+      - git
+      - git-filter-repo
+    state: latest
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
-  block:
-    - name: Install git (linux)
-      ansible.builtin.apt:
-        name: git
-        state: latest
-
-# TODO: install git-filter-repo on linux
 
 - name: Install git (macos)
   when: ansible_distribution == 'MacOSX'


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Installs `git-filter-repo` on Linux (Debian/Ubuntu) via `apt`, which was previously a `TODO`. Both `git` and `git-filter-repo` are now installed in a single `apt` task, matching the macOS side which already installs both.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
