### PR TITLE
Add linux install to communication/mattermost role

### DIFF
--- a/roles/communication/mattermost/tasks/main.yml
+++ b/roles/communication/mattermost/tasks/main.yml
@@ -1,5 +1,24 @@
 ---
-# TODO: install mattermost on linux
+- name: Install mattermost (linux)
+  become: true
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  block:
+    - name: Add mattermost repository (linux)
+      ansible.builtin.deb822_repository:
+        name: mattermost
+        types: [deb]
+        uris: [https://deb.packages.mattermost.com]
+        suites: [stable]
+        components: [main]
+        architectures: [amd64]
+        signed_by: https://deb.packages.mattermost.com/pubkey.gpg
+        state: present
+
+    - name: Install mattermost (linux)
+      ansible.builtin.apt:
+        name: mattermost-desktop
+        update_cache: true
+        state: latest
 
 - name: Install mattermost (macos)
   community.general.homebrew_cask:


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Installs the Mattermost desktop app on Linux via the official Mattermost apt repository (deb.packages.mattermost.com). Was a TODO.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
