### PR TITLE
Add linux install to communication/teams role

### DIFF
--- a/roles/communication/teams/tasks/main.yml
+++ b/roles/communication/teams/tasks/main.yml
@@ -1,5 +1,38 @@
 ---
-# TODO: install microsoft-teams on linux
+- name: Install teams (linux)
+  become: true
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  block:
+    - name: Read browser desktop file (linux)
+      ansible.builtin.slurp:
+        src: /usr/share/applications/{{ browser.default }}.desktop
+      register: browser_file
+
+    - name: Extract browser executable (linux)
+      ansible.builtin.set_fact:
+        browser_executable: "{{ browser_file.content | b64decode | regex_search('^Exec=([^ ]*).*', '\\1', multiline=True) | first }}"
+
+    - name: Ensure icons folder exists (linux)
+      ansible.builtin.file:
+        path: /usr/share/applications/icons
+        state: directory
+        mode: "0755"
+
+    - name: Download teams icon (linux)
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/homarr-labs/dashboard-icons/refs/heads/main/png/microsoft-teams.png
+        dest: /usr/share/applications/icons/teams.png
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Copy teams desktop file (linux)
+      ansible.builtin.template:
+        src: templates/teams/teams.desktop.j2
+        dest: /usr/share/applications/teams.desktop
+        owner: root
+        group: root
+        mode: "0644"
 
 - name: Install teams (macos)
   community.general.homebrew_cask:

--- a/roles/communication/teams/templates/teams/teams.desktop.j2
+++ b/roles/communication/teams/templates/teams/teams.desktop.j2
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Microsoft Teams
+Comment=Microsoft Teams
+Exec={{ browser_executable }} --app="https://teams.microsoft.com/"
+Terminal=false
+Type=Application
+Icon=/usr/share/applications/icons/teams.png
+StartupNotify=true


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a Microsoft Teams web-app .desktop launcher on Linux (opens teams.microsoft.com in the default browser), since there is no native Linux Teams client. Mirrors the whatsapp role pattern. Was a TODO.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
