### PR TITLE
Add linux install to development/rust role

### DIFF
--- a/playbook-linux.yml
+++ b/playbook-linux.yml
@@ -82,6 +82,7 @@
     - development/packer
     - development/python
     - development/ruby
+    - development/rust
     - development/terraform
     - development/vagrant
     - development/aws
@@ -103,7 +104,6 @@
     - development/psql
     - development/pter
     - development/rtk
-    - development/rust
     - development/uv
     - media/easy-effects
     - media/eog

--- a/roles/development/rust/tasks/main.yml
+++ b/roles/development/rust/tasks/main.yml
@@ -1,26 +1,35 @@
 ---
-# TODO: install rust on linux
+- name: Install rustup (linux)
+  become: true
+  ansible.builtin.apt:
+    name: rustup
+    state: latest
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
-- name: Install rust (macos)
+- name: Install rustup (macos)
+  community.general.homebrew:
+    name: rustup
+    state: latest
   when: ansible_distribution == 'MacOSX'
-  block:
-    - name: Install rustup (macos)
-      community.general.homebrew:
-        name: rustup
-        state: latest
 
-    - name: Check rust active toolchain (macos)
-      ansible.builtin.command: /opt/homebrew/opt/rustup/bin/rustup show active-toolchain
-      register: rust_toolchain
-      changed_when: false
-      failed_when: false
+- name: Check rust active toolchain (linux/macos)
+  ansible.builtin.command: rustup show active-toolchain
+  environment:
+    PATH: "/opt/homebrew/opt/rustup/bin:{{ ansible_env.PATH }}"
+  register: rust_toolchain
+  changed_when: false
+  failed_when: false
 
-    - name: Install rust stable toolchain (macos)
-      ansible.builtin.command: /opt/homebrew/opt/rustup/bin/rustup default stable
-      changed_when: true
-      when: "'stable' not in (rust_toolchain.stdout | default(''))"
+- name: Install rust stable toolchain (linux/macos)
+  ansible.builtin.command: rustup default stable
+  environment:
+    PATH: "/opt/homebrew/opt/rustup/bin:{{ ansible_env.PATH }}"
+  changed_when: true
+  when: "'stable' not in (rust_toolchain.stdout | default(''))"
 
-    - name: Install rust components (macos)
-      ansible.builtin.command: /opt/homebrew/opt/rustup/bin/rustup component add {{ rust.components | join(' ') }}
-      register: rust_components
-      changed_when: "'installing component' in rust_components.stderr"
+- name: Install rust components (linux/macos)
+  ansible.builtin.command: rustup component add {{ rust.components | join(' ') }}
+  environment:
+    PATH: "/opt/homebrew/opt/rustup/bin:{{ ansible_env.PATH }}"
+  register: rust_components
+  changed_when: "'installing component' in rust_components.stderr"


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Installs Rust on Linux via apt (rustup) and shares the toolchain setup (rustup default stable plus components) across Linux and macOS. Also moves development/rust in playbook-linux.yml to sit after development/ruby, matching playbook-macos.yml.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
