### PR TITLE
Add linux install to development/duckdb role

### DIFF
--- a/roles/development/duckdb/tasks/main.yml
+++ b/roles/development/duckdb/tasks/main.yml
@@ -1,5 +1,31 @@
 ---
-# TODO: install duckdb on linux
+- name: Install duckdb (linux)
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  block:
+    - name: Get duckdb release (linux)
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/duckdb/duckdb/releases/latest
+        return_content: true
+      register: duckdb_release
+
+    - name: Create duckdb directory (linux)
+      ansible.builtin.file:
+        path: /home/{{ ansible_user }}/.duckdb/cli/{{ duckdb_release.json.tag_name | regex_replace('^v', '') }}
+        state: directory
+        mode: "0755"
+
+    - name: Install duckdb (linux)
+      ansible.builtin.unarchive:
+        src: https://github.com/duckdb/duckdb/releases/download/{{ duckdb_release.json.tag_name }}/duckdb_cli-linux-amd64.zip
+        dest: /home/{{ ansible_user }}/.duckdb/cli/{{ duckdb_release.json.tag_name | regex_replace('^v', '') }}
+        remote_src: true
+        mode: "0755"
+
+    - name: Link duckdb latest (linux)
+      ansible.builtin.file:
+        src: /home/{{ ansible_user }}/.duckdb/cli/{{ duckdb_release.json.tag_name | regex_replace('^v', '') }}
+        dest: /home/{{ ansible_user }}/.duckdb/cli/latest
+        state: link
 
 - name: Install duckdb (macos)
   community.general.homebrew:


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Installs the DuckDB CLI on Linux to ~/.duckdb/cli/<version> with a latest symlink (matching the official install script layout), from the latest GitHub release. Was a TODO.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
