### PR TITLE
Remove linux TODO from productivity/meetily role

### DIFF
--- a/roles/productivity/meetily/tasks/main.yml
+++ b/roles/productivity/meetily/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# TODO: install meetily on linux
-
 - name: Install meetily (macOS)
   when: ansible_distribution == 'MacOSX'
   block:


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Meetily has no official Linux build (source-build only), so this drops the Linux TODO and leaves the role macOS-only. The role stays listed in playbook-linux.yml (a no-op on Linux).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
