### PR TITLE
Remove linux TODO from productivity/office role

### DIFF
--- a/roles/productivity/office/tasks/main.yml
+++ b/roles/productivity/office/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# TODO: install microsoft-office on linux
-
 - name: Install microsoft-office (macos)
   community.general.homebrew_cask:
     name: microsoft-office


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Microsoft Office has no native Linux client, so this drops the Linux TODO and leaves the role macOS-only. The role stays listed in playbook-linux.yml (a no-op on Linux).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
