### PR TITLE
Add build dependencies to development/python role

### DIFF
--- a/roles/development/python/tasks/main.yml
+++ b/roles/development/python/tasks/main.yml
@@ -16,6 +16,7 @@
     - name: Install python dependencies (linux)
       ansible.builtin.apt:
         name:
+          # Compilation dependencies
           - libb2-dev
           - libbz2-dev
           - libdbus-1-3
@@ -37,6 +38,12 @@
           - tk-dev
           - uuid-dev
           - zlib1g-dev
+          # Package dependencies
+          - libcairo2-dev
+          - libdbus-1-dev
+          - libgirepository-2.0-dev
+          - libglib2.0-dev
+          - python3-dev
         update_cache: true
         state: present
 


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds apt build/development dependencies to the Linux install of the `development/python` role (`libcairo2-dev`, `libdbus-1-dev`, `libgirepository-2.0-dev`, `libglib2.0-dev`, `python3-dev`) so building Python and common native Python packages works on Linux. Also groups the existing dependencies under `Compilation dependencies` / `Package dependencies` comments.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
